### PR TITLE
Issue/50

### DIFF
--- a/assets/src/js/admin-main.js
+++ b/assets/src/js/admin-main.js
@@ -1,4 +1,5 @@
 import SettingsTabs from './settings-tabs';
+import FacebookPagesField from './facebook-pages-field';
 import Builder from './builder';
 import '../css/admin-main.scss';
 import '../images/wpbr-logo-white-wordmark.png';
@@ -6,8 +7,11 @@ import '../images/wpbr-menu-icon-white.png';
 import '../images/wpbr-icon-color.png';
 
 if ( document.querySelector( 'body' ).classList.contains( 'wpbr_review_page_wpbr_settings' ) ) {
-	const settingsTabs = new SettingsTabs( '.js-wpbr-settings' );
+	const settingsTabs       = new SettingsTabs( '.js-wpbr-settings' );
+	const facebookPagesField = new FacebookPagesField( 'facebook_pages' );
+
 	settingsTabs.init();
+	facebookPagesField.init();
 }
 
 if ( document.querySelector( 'body' ).classList.contains( 'wpbr_review_page_wpbr_builder' ) ) {

--- a/assets/src/js/admin-main.js
+++ b/assets/src/js/admin-main.js
@@ -1,4 +1,4 @@
-import Settings from './settings';
+import SettingsTabs from './settings-tabs';
 import Builder from './builder';
 import '../css/admin-main.scss';
 import '../images/wpbr-logo-white-wordmark.png';
@@ -6,8 +6,8 @@ import '../images/wpbr-menu-icon-white.png';
 import '../images/wpbr-icon-color.png';
 
 if ( document.querySelector( 'body' ).classList.contains( 'wpbr_review_page_wpbr_settings' ) ) {
-	const settings = new Settings( '.js-wpbr-settings' );
-	settings.init();
+	const settingsTabs = new SettingsTabs( '.js-wpbr-settings' );
+	settingsTabs.init();
 }
 
 if ( document.querySelector( 'body' ).classList.contains( 'wpbr_review_page_wpbr_builder' ) ) {

--- a/assets/src/js/facebook-pages-field.js
+++ b/assets/src/js/facebook-pages-field.js
@@ -1,0 +1,19 @@
+import Field from './field';
+
+class FacebookPagesField extends Field {
+	constructor( name ) {
+		super( name );
+	}
+
+	disconnect() {
+
+		// Disconnect Facebook.
+	}
+
+	registerEventHandlers() {
+
+		// Add 'click' event listener to Disconnect button.
+	}
+}
+
+export default FacebookPagesField;

--- a/assets/src/js/facebook-pages-field.js
+++ b/assets/src/js/facebook-pages-field.js
@@ -3,16 +3,27 @@ import Field from './field';
 class FacebookPagesField extends Field {
 	constructor( name ) {
 		super( name );
+
+		if ( null !== this.root ) {
+			this.disconnectButton = this.root.querySelector( '.js-wpbr-facebook-disconnect' );
+		}
+	}
+
+	init() {
+		this.registerEventHandlers();
 	}
 
 	disconnect() {
-
-		// Disconnect Facebook.
+		this.root.parentNode.querySelector( '.js-wpbr-action' ).value = 'wp_business_reviews_disconnect_facebook';
 	}
 
-	registerEventHandlers() {
 
-		// Add 'click' event listener to Disconnect button.
+	registerEventHandlers() {
+		if ( null !== this.disconnectButton ) {
+			this.disconnectButton.addEventListener( 'click', ( event ) => {
+				this.disconnect();
+			}, this );
+		}
 	}
 }
 

--- a/assets/src/js/field.js
+++ b/assets/src/js/field.js
@@ -1,16 +1,11 @@
 class Field {
 	constructor( name ) {
-		this.field = document.getElementById( `wpbr-field-${name}` );
-		this.label = document.getElementById( `wpbr-label-${name}` );
-		this.tooltip = document.getElementById( `wpbr-tooltip-${name}` );
 		this.control = document.getElementById( `wpbr-control-${name}` );
-		this.description = document.getElementById( `wpbr-description-${name}` );
 	}
 
-	getValue() {
+	get value() {
 		return this.control.value;
 	}
-
 }
 
 export default Field;

--- a/assets/src/js/field.js
+++ b/assets/src/js/field.js
@@ -1,5 +1,6 @@
 class Field {
 	constructor( name ) {
+		this.root    = document.getElementById( `wpbr-field-${name}` );
 		this.control = document.getElementById( `wpbr-control-${name}` );
 	}
 

--- a/assets/src/js/settings-tabs.js
+++ b/assets/src/js/settings-tabs.js
@@ -1,6 +1,6 @@
 import queryString from 'query-string';
 
-class Settings {
+class SettingsTabs {
 	constructor( selector ) {
 
 		// Define the root element of the Settings UI.
@@ -30,6 +30,7 @@ class Settings {
 		this.panels = this.root.querySelectorAll( '.js-wpbr-panel' );
 		this.subtabs = this.root.querySelectorAll( '.js-wpbr-subtab' );
 		this.sections = this.root.querySelectorAll( '.js-wpbr-section' );
+		this.disconnectButton = this.root.querySelector( '.js-wpbr-facebook-disconnect' );
 
 		// Define default active elements.
 		this.activeTab = this.tabs[0];
@@ -138,6 +139,27 @@ class Settings {
 		history.pushState( null, null, `?${queryString.stringify( this.queryStringObject )}` );
 	}
 
+	disconnectFacebook() {
+		console.log( 'fb click' );
+		var data = {
+			'action': 'my_action',
+			'whatever': 1234
+		};
+
+		jQuery.post( ajaxurl, data, function( response ) {
+			alert( 'Got this from the server: ' + response );
+		});
+	}
+
+	registerFacebookButtonHandler() {
+		if ( null != this.disconnectButton ) {
+			this.disconnectButton.addEventListener( 'click', ( event ) => {
+				event.preventDefault();
+				this.disconnectFacebook();
+			}, this );
+		}
+	}
+
 	registerTabEventHandlers() {
 		this.tabs.forEach( ( tab ) => {
 			tab.addEventListener( 'click', ( event ) => {
@@ -151,6 +173,7 @@ class Settings {
 				}
 			});
 		}, this );
+		this.registerFacebookButtonHandler();
 	}
 
 	registerSubtabEventHandlers() {
@@ -177,4 +200,4 @@ class Settings {
 	}
 }
 
-export default Settings;
+export default SettingsTabs;

--- a/assets/src/js/settings-tabs.js
+++ b/assets/src/js/settings-tabs.js
@@ -30,7 +30,6 @@ class SettingsTabs {
 		this.panels = this.root.querySelectorAll( '.js-wpbr-panel' );
 		this.subtabs = this.root.querySelectorAll( '.js-wpbr-subtab' );
 		this.sections = this.root.querySelectorAll( '.js-wpbr-section' );
-		this.disconnectButton = this.root.querySelector( '.js-wpbr-facebook-disconnect' );
 
 		// Define default active elements.
 		this.activeTab = this.tabs[0];
@@ -139,27 +138,6 @@ class SettingsTabs {
 		history.pushState( null, null, `?${queryString.stringify( this.queryStringObject )}` );
 	}
 
-	disconnectFacebook() {
-		console.log( 'fb click' );
-		var data = {
-			'action': 'my_action',
-			'whatever': 1234
-		};
-
-		jQuery.post( ajaxurl, data, function( response ) {
-			alert( 'Got this from the server: ' + response );
-		});
-	}
-
-	registerFacebookButtonHandler() {
-		if ( null != this.disconnectButton ) {
-			this.disconnectButton.addEventListener( 'click', ( event ) => {
-				event.preventDefault();
-				this.disconnectFacebook();
-			}, this );
-		}
-	}
-
 	registerTabEventHandlers() {
 		this.tabs.forEach( ( tab ) => {
 			tab.addEventListener( 'click', ( event ) => {
@@ -173,7 +151,6 @@ class SettingsTabs {
 				}
 			});
 		}, this );
-		this.registerFacebookButtonHandler();
 	}
 
 	registerSubtabEventHandlers() {

--- a/includes/class-facebook-page-manager.php
+++ b/includes/class-facebook-page-manager.php
@@ -95,7 +95,10 @@ class Facebook_Page_Manager {
 	 * @return bool True if token saved, false otherwise.
 	 */
 	public function save_user_token() {
-		if ( ! isset( $_POST['wpbr_facebook_user_token'] ) ) {
+		if (
+			! isset( $_POST['wpbr_facebook_user_token'] )
+			|| ! $this->serializer->has_permission()
+		) {
 			return false;
 		}
 
@@ -111,6 +114,7 @@ class Facebook_Page_Manager {
 			 * @since 0.1.0
 			 */
 			do_action( 'wp_business_reviews_facebook_user_token_saved', 'facebook' );
+
 			return true;
 		} else {
 			return false;
@@ -125,12 +129,15 @@ class Facebook_Page_Manager {
 	 * @return bool True if pages saved, false otherwise.
 	 */
 	public function save_pages() {
-		if ( ! $this->request->has_token() ) {
+		if (
+			! $this->serializer->has_permission()
+			|| ! $this->request->has_token()
+		) {
 			return false;
 		}
 
-		$pages = array();
-		$response  = $this->request->get_pages();
+		$pages    = array();
+		$response = $this->request->get_pages();
 
 		// Process the array of pages and pull out only the keys we need.
 		if ( isset( $response['data'] ) ) {

--- a/includes/class-facebook-page-manager.php
+++ b/includes/class-facebook-page-manager.php
@@ -61,18 +61,47 @@ class Facebook_Page_Manager {
 	 * @since 0.1.0
 	 */
 	public function register() {
-		add_action( 'wp_business_reviews_admin_page_wpbr_settings', array( $this, 'save_token' ), 1 );
+		add_action( 'wp_business_reviews_admin_page_wpbr_settings', array( $this, 'save_user_token' ), 1 );
 		add_action( 'wp_business_reviews_admin_page_wpbr_settings', array( $this, 'save_pages' ), 1 );
+		add_action( 'admin_post_wp_business_reviews_disconnect_facebook', array( $this, 'disconnect' ) );
 	}
 
-	public function save_token() {
+	/**
+	 * Resets all Facebook settings.
+	 *
+	 * @since 0.1.0
+	 */
+	public function disconnect() {
+		if (
+			$this->serializer->has_valid_nonce( 'wp_business_reviews_save_settings', 'wp_business_reviews_settings_nonce' )
+			&& $this->serializer->has_permission()
+		) {
+			$facebook_settings = array(
+				'facebook_user_token' => '',
+				'facebook_platform_status' => '',
+				'facebook_pages' => '',
+			);
+			$this->serializer->save_multiple( $facebook_settings );
+		}
+
+		$this->serializer->redirect();
+	}
+
+	/**
+	 * Saves Facebook user token.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return bool True if token saved, false otherwise.
+	 */
+	public function save_user_token() {
 		if ( ! isset( $_POST['wpbr_facebook_user_token'] ) ) {
 			return false;
 		}
 
 		$token = sanitize_text_field( $_POST['wpbr_facebook_user_token'] );
 
-		// Update the request token so it can be used in other methods.
+		// Set the request token so it can be used in other methods.
 		$this->request->set_token( $token );
 
 		if ( $this->serializer->save( 'facebook_user_token', $token ) ) {
@@ -90,6 +119,8 @@ class Facebook_Page_Manager {
 
 	/**
 	 * Saves Facebook page names and tokens.
+	 *
+	 * @since 0.1.0
 	 *
 	 * @return bool True if pages saved, false otherwise.
 	 */

--- a/includes/class-platform-manager.php
+++ b/includes/class-platform-manager.php
@@ -202,8 +202,6 @@ class Platform_Manager {
 			}
 		}
 
-		error_log( print_r( $connected_platforms, true ) );
-
 		return array_intersect_key( $this->platforms, $connected_platforms );
 	}
 

--- a/includes/deserializer/class-deserializer-abstract.php
+++ b/includes/deserializer/class-deserializer-abstract.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Defines the Deserializer_Abstract class
+ *
+ * @link https://wpbusinessreviews.com
+ *
+ * @package WP_Business_Reviews\Includes\Deserializer
+ * @since 0.1.0
+ */
+
+namespace WP_Business_Reviews\Includes\Deserializer;
+
+/**
+ * Retrieves values from the database.
+ *
+ * @since 0.1.0
+ */
+abstract class Deserializer_Abstract {
+	/**
+	 * The prefix prepended to the retrieved key.
+	 *
+	 * @since 0.1.0
+	 * @var string $prefix
+	 */
+	protected $prefix = 'wp_business_reviews_';
+
+	/**
+	 * Retrieves a value from the database.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $key    Key of the value to retrieve.
+	 * @param string $subkey Optional. If value is an array and subkey is
+	 *                       defined, only the subkey's value is returned.
+	 * @return mixed The stored value.
+	 */
+	abstract public function get( $key, $subkey = false );
+}

--- a/includes/deserializer/class-option-deserializer.php
+++ b/includes/deserializer/class-option-deserializer.php
@@ -15,22 +15,16 @@ namespace WP_Business_Reviews\Includes\Deserializer;
  *
  * @since 0.1.0
  */
-class Option_Deserializer {
+class Option_Deserializer extends Deserializer_Abstract {
 	/**
-	 * Retrieves a value from the database.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param string $option  Name of the option to retrieve.
-	 * @param string $key     Optional. Specific array key for when the
-	 *                        option's value is an array.
+	 * @inheritDoc
 	 */
-	public function get( $option, $key = false ) {
-		$value = get_option( 'wp_business_reviews_' . $option );
+	public function get( $key, $subkey = false ) {
+		$value = get_option( $this->prefix . $key );
 
-		if ( false !== $key ) {
-			if ( isset( $value[ $key ] ) ) {
-				return $value[ $key ];
+		if ( false !== $subkey ) {
+			if ( isset( $value[ $subkey ] ) ) {
+				return $value[ $subkey ];
 			} else {
 				return null;
 			}

--- a/includes/serializer/class-option-serializer.php
+++ b/includes/serializer/class-option-serializer.php
@@ -74,7 +74,7 @@ class Option_Serializer extends Serializer_Abstract {
 	 *
 	 * @since 0.1.0
 	 */
-	protected function redirect() {
+	public function redirect() {
 		$active_tab = $active_subtab = $referer = '';
 
 		if ( ! empty( $_POST['_wp_http_referer'] ) ) {

--- a/includes/serializer/class-option-serializer.php
+++ b/includes/serializer/class-option-serializer.php
@@ -22,15 +22,15 @@ class Option_Serializer {
 	 * @since 0.1.0
 	 */
 	public function register() {
-		add_action( 'admin_post_wp_business_reviews_save_settings', array( $this, 'save_all' ) );
+		add_action( 'admin_post_wp_business_reviews_save_settings', array( $this, 'save_section' ) );
 	}
 
 	/**
-	 * Saves all settings to database.
+	 * Saves settings section to database.
 	 *
 	 * @since 0.1.0
 	 */
-	public function save_all() {
+	public function save_section() {
 		// Make sure settings exist.
 		if ( empty( $_POST['wp_business_reviews_settings'] ) ) {
 			$this->redirect();

--- a/includes/serializer/class-option-serializer.php
+++ b/includes/serializer/class-option-serializer.php
@@ -11,7 +11,7 @@
 namespace WP_Business_Reviews\Includes\Serializer;
 
 /**
- * Saves information to the database.
+ * Saves options to the database.
  *
  * @since 0.1.0
  */
@@ -26,7 +26,7 @@ class Option_Serializer {
 	}
 
 	/**
-	 * Saves all valid settings to database.
+	 * Saves all settings to database.
 	 *
 	 * @since 0.1.0
 	 */
@@ -40,8 +40,8 @@ class Option_Serializer {
 
 		// Validate nonce and verify user has permission to save.
 		if ( $this->has_valid_nonce() && $this->has_permission() ) {
-			foreach ( $settings as $setting => $value ) {
-				$this->save( $setting, $value);
+			foreach ( $settings as $option => $value ) {
+				$this->save( $option, $value);
 			}
 
 			$section = sanitize_text_field( $_POST['wp_business_reviews_subtab'] );
@@ -62,16 +62,16 @@ class Option_Serializer {
 	}
 
 	/**
-	 * Saves a single sanitized setting to the database.
+	 * Saves a single sanitized option to the database.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $setting Key of the setting being saved.
-	 * @param mixed  $value   Value of the setting being saved.
+	 * @param string $option Name of the option being saved.
+	 * @param mixed  $value  Value of the option being saved.
 	 * @return boolean True if option saved successfully, false otherwise.
 	 */
-	public function save( $setting, $value ) {
-		return update_option( 'wp_business_reviews_' . $setting, $this->clean( $value ) );
+	public function save( $option, $value ) {
+		return update_option( 'wp_business_reviews_' . $option, $this->clean( $value ) );
 	}
 
 	/**
@@ -108,7 +108,7 @@ class Option_Serializer {
 	}
 
 	/**
-	 * Verifies user has permission to save settings.
+	 * Verifies user has permission to save.
 	 *
 	 * @since 0.1.0
 	 *

--- a/includes/serializer/class-option-serializer.php
+++ b/includes/serializer/class-option-serializer.php
@@ -15,7 +15,7 @@ namespace WP_Business_Reviews\Includes\Serializer;
  *
  * @since 0.1.0
  */
-class Option_Serializer {
+class Option_Serializer extends Serializer_Abstract {
 	/**
 	 * Registers functionality with WordPress hooks.
 	 *
@@ -23,6 +23,13 @@ class Option_Serializer {
 	 */
 	public function register() {
 		add_action( 'admin_post_wp_business_reviews_save_settings', array( $this, 'save_section' ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function save( $key, $value ) {
+		return update_option( $this->prefix . $key, $this->clean( $value ) );
 	}
 
 	/**
@@ -36,15 +43,14 @@ class Option_Serializer {
 			$this->redirect();
 		}
 
-		$settings = $_POST['wp_business_reviews_settings'];
-
-		// Validate nonce and verify user has permission to save.
-		if ( $this->has_valid_nonce() && $this->has_permission() ) {
-			foreach ( $settings as $option => $value ) {
-				$this->save( $option, $value);
-			}
-
+		if (
+			$this->has_valid_nonce( 'wp_business_reviews_save_settings', 'wp_business_reviews_settings_nonce' )
+			&& $this->has_permission()
+		) {
+			$settings = $_POST['wp_business_reviews_settings'];
 			$section = sanitize_text_field( $_POST['wp_business_reviews_subtab'] );
+
+			$this->save_multiple( $settings );
 
 			/**
 			 * Fires after all posted settings have been saved.
@@ -62,68 +68,6 @@ class Option_Serializer {
 	}
 
 	/**
-	 * Saves a single sanitized option to the database.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param string $option Name of the option being saved.
-	 * @param mixed  $value  Value of the option being saved.
-	 * @return boolean True if option saved successfully, false otherwise.
-	 */
-	public function save( $option, $value ) {
-		return update_option( 'wp_business_reviews_' . $option, $this->clean( $value ) );
-	}
-
-	/**
-	 * Recursively sanitizes a given value.
-	 *
-	 * @param string|array $value Value to be sanitized.
-	 * @return string|array Array of clean values or single clean value.
-	 */
-	protected function clean( $value ) {
-		if ( is_array( $value ) ) {
-			return array_map( array( $this, 'clean' ), $value );
-		} else {
-			return is_scalar( $value ) ? sanitize_text_field( $value ) : '';
-		}
-	}
-
-	/**
-	 * Determines if a valid nonce has been provided.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @return boolean True if valid, false if invalid.
-	 */
-	protected function has_valid_nonce() {
-		if ( ! empty( $_POST['wp_business_reviews_settings_nonce'] ) ) {
-			$nonce = sanitize_text_field( wp_unslash( $_POST['wp_business_reviews_settings_nonce'] ) );
-		} else {
-			// Nonce field is not present or not populated, and therefore invalid.
-			error_log( 'invalid nonce' );
-			return false;
-		}
-
-		return wp_verify_nonce( $nonce, 'wp_business_reviews_save_settings' );
-	}
-
-	/**
-	 * Verifies user has permission to save.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @return boolean True if user has permission, false if not.
-	 */
-	protected function has_permission() {
-		if ( current_user_can( 'manage_options' ) ) {
-			return true;
-		} else {
-			error_log( 'user does not have permission' );
-			return false;
-		}
-	}
-
-	/**
 	 * Redirects to the page from which settings were saved.
 	 *
 	 * If an active tab or subtab is provided, it will be included in the redirect URL.
@@ -133,6 +77,14 @@ class Option_Serializer {
 	protected function redirect() {
 		$active_tab = $active_subtab = $referer = '';
 
+		if ( ! empty( $_POST['_wp_http_referer'] ) ) {
+			$referer = sanitize_text_field( wp_unslash( $_POST['_wp_http_referer'] ) );
+		} else {
+			$referer = wp_login_url();
+			wp_safe_redirect( $redirect );
+			exit;
+		}
+
 		if ( ! empty( $_POST['wp_business_reviews_tab'] ) ) {
 			$active_tab = sanitize_text_field( wp_unslash( $_POST['wp_business_reviews_tab'] ) );
 		}
@@ -141,24 +93,18 @@ class Option_Serializer {
 			$active_subtab = sanitize_text_field( wp_unslash( $_POST['wp_business_reviews_subtab'] ) );
 		}
 
-		if ( ! empty( $_POST['_wp_http_referer'] ) ) {
-			$referer = sanitize_text_field( wp_unslash( $_POST['_wp_http_referer'] ) );
-		} else {
-			$referer = wp_login_url();
-		}
-
 		// Parse referer into path and query string.
 		$parsed_url = parse_url( $referer );
 
 		// Parse query string into array of query parts.
-		parse_str( $parsed_url['query'], $query_parts );
+		parse_str( $parsed_url['query'], $query_args );
 
 		// Update active tab and subtab.
-		$query_parts['wpbr_tab'] = $active_tab;
-		$query_parts['wpbr_subtab'] = $active_subtab;
+		$query_args['wpbr_tab']    = $active_tab;
+		$query_args['wpbr_subtab'] = $active_subtab;
 
 		// Stringify the query parts.
-		$query_string = http_build_query( $query_parts );
+		$query_string = http_build_query( $query_args );
 
 		// Assemble the redirect location.
 		$redirect = $parsed_url['path'] . '?' . $query_string;

--- a/includes/serializer/class-serializer-abstract.php
+++ b/includes/serializer/class-serializer-abstract.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Defines the Serializer_Abstract class
+ *
+ * @link https://wpbusinessreviews.com
+ *
+ * @package WP_Business_Reviews\Includes\Serializer
+ * @since 0.1.0
+ */
+
+namespace WP_Business_Reviews\Includes\Serializer;
+
+/**
+ * Saves values to the database.
+ *
+ * @since 0.1.0
+ */
+abstract class Serializer_Abstract {
+	/**
+	 * The prefix prepended to the saved key.
+	 *
+	 * @since 0.1.0
+	 * @var string $prefix
+	 */
+	protected $prefix = 'wp_business_reviews_';
+
+	/**
+	 * Saves a single sanitized value to the database.
+	 *
+	 * This method should make use of the `clean` method prior to saving.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $key   The key being saved.
+	 * @param mixed  $value The value being saved.
+	 * @return boolean True if value saved successfully, false otherwise.
+	 */
+	abstract public function save( $key, $value );
+
+	/**
+	 * Saves an array of key-value pairs to the database.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param $values Key-value pairs to be saved.
+	 */
+	public function save_multiple( array $values ) {
+		foreach ( $values as $key => $value ) {
+			$this->save( $key, $value );
+		}
+	}
+
+	/**
+	 * Recursively sanitizes a given value.
+	 *
+	 * @param string|array $value The value to be sanitized.
+	 * @return string|array Array of clean values or single clean value.
+	 */
+	protected function clean( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( array( $this, 'clean' ), $value );
+		} else {
+			return is_scalar( $value ) ? sanitize_text_field( $value ) : '';
+		}
+	}
+
+	/**
+	 * Determines if a valid nonce has been provided.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string|int $action Should give context to what is taking place and be the same when nonce was created.
+	 * @param string     $name   Nonce name.
+	 * @return false|int False if the nonce is invalid, 1 if the nonce is valid and generated between
+	 *                   0-12 hours ago, 2 if the nonce is valid and generated between 12-24 hours ago.
+	 */
+	protected function has_valid_nonce( $action, $name ) {
+		if ( empty( $_POST[ $name ] ) ) {
+			// Nonce field is not present or not populated, and therefore invalid.
+			return false;
+		}
+
+		$nonce = sanitize_text_field( wp_unslash( $_POST[ $name ] ) );
+
+		return wp_verify_nonce( $nonce, $action );
+	}
+
+	/**
+	 * Verifies user has permission to save.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $capability Capability name.
+	 * @return boolean True if user has permission, false if not.
+	 */
+	protected function has_permission( $capability = 'manage_options' ) {
+		return current_user_can( $capability );
+	}
+}

--- a/includes/serializer/class-serializer-abstract.php
+++ b/includes/serializer/class-serializer-abstract.php
@@ -25,6 +25,14 @@ abstract class Serializer_Abstract {
 	protected $prefix = 'wp_business_reviews_';
 
 	/**
+	 * User capability required in order to save.
+	 *
+	 * @since 0.1.0
+	 * @var string $capability
+	 */
+	protected $capability = 'manage_options';
+
+	/**
 	 * Saves a single sanitized value to the database.
 	 *
 	 * @since 0.1.0
@@ -88,10 +96,9 @@ abstract class Serializer_Abstract {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $capability Capability name.
 	 * @return boolean True if user has permission, false if not.
 	 */
-	protected function has_permission( $capability = 'manage_options' ) {
-		return current_user_can( $capability );
+	protected function has_permission() {
+		return current_user_can( $this->capability );
 	}
 }

--- a/includes/serializer/class-serializer-abstract.php
+++ b/includes/serializer/class-serializer-abstract.php
@@ -27,8 +27,6 @@ abstract class Serializer_Abstract {
 	/**
 	 * Saves a single sanitized value to the database.
 	 *
-	 * This method should make use of the `clean` method prior to saving.
-	 *
 	 * @since 0.1.0
 	 *
 	 * @param string $key   The key being saved.

--- a/includes/serializer/class-serializer-abstract.php
+++ b/includes/serializer/class-serializer-abstract.php
@@ -80,7 +80,7 @@ abstract class Serializer_Abstract {
 	 * @return false|int False if the nonce is invalid, 1 if the nonce is valid and generated between
 	 *                   0-12 hours ago, 2 if the nonce is valid and generated between 12-24 hours ago.
 	 */
-	protected function has_valid_nonce( $action, $name ) {
+	public function has_valid_nonce( $action, $name ) {
 		if ( empty( $_POST[ $name ] ) ) {
 			// Nonce field is not present or not populated, and therefore invalid.
 			return false;
@@ -98,7 +98,7 @@ abstract class Serializer_Abstract {
 	 *
 	 * @return boolean True if user has permission, false if not.
 	 */
-	protected function has_permission() {
+	public function has_permission() {
 		return current_user_can( $this->capability );
 	}
 }

--- a/views/field/controls/control-facebook-pages.php
+++ b/views/field/controls/control-facebook-pages.php
@@ -16,14 +16,7 @@
 			</li>
 		<?php endforeach; ?>
 	</ul>
-	<ul class="wpbr-inline-list">
-		<li class="wpbr-inline-list__item">
-			<button class="button button-primary"><?php _e( 'Refresh Pages', 'wp-business-reviews' ); ?></button>
-		</li>
-		<li class="wpbr-inline-list__item">
-			<button class="button"><?php esc_html_e( 'Disconnect Facebook', 'wp-business-reviews' ) ?></button>
-		</li>
-	</ul>
+	<button class="button js-wpbr-facebook-disconnect"><?php esc_html_e( 'Disconnect Facebook', 'wp-business-reviews' ) ?></button>
 <?php else : ?>
 	<?php
 	if ( 'development' === WPBR_ENV ) {

--- a/views/plugin-settings/plugin-settings-panel-main.php
+++ b/views/plugin-settings/plugin-settings-panel-main.php
@@ -34,7 +34,7 @@
 
 			<?php if ( ! empty( $section['fields'] ) ) : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-					<input type="hidden" name="action" value="wp_business_reviews_save_settings">
+					<input class="js-wpbr-action" type="hidden" name="action" value="wp_business_reviews_save_settings">
 					<input type="hidden" name="wp_business_reviews_tab" value="<?php echo esc_attr( $this->tab_id ); ?>">
 					<input type="hidden" name="wp_business_reviews_subtab" value="<?php echo esc_attr( $section_id ); ?>">
 					<?php


### PR DESCRIPTION
## Description

Resolves #50 by adding functionality to disconnect Facebook. Doing so clears all Facebook-related settings in the database. It does _not_ remove the WP Business Reviews app within Facebook.

## Video

https://soapbox.wistia.com/videos/QOayiaqNJ7

## Types of Changes

- UX - User can now disconnect Facebook in one click.
- JS - Added `Field` class that can be extended, for example, to `FacebookPagesField`.
- PHP - Created `Serializer_Abstract` and `Deserializer_Abstract` classes so that subclasses can leverage shared functionality.