### PR TITLE
Issue #71 - Trigger platform search with Enter key

### DIFF
--- a/assets/src/js/platform-search-field.js
+++ b/assets/src/js/platform-search-field.js
@@ -12,7 +12,7 @@ class PlatformSearchField extends Field {
 
 	init() {
 		this.initSubfields();
-		this.registerSearchButtonEventHandlers();
+		this.registerSearchEventHandlers();
 	}
 
 	initSubfields() {
@@ -58,10 +58,31 @@ class PlatformSearchField extends Field {
 		this.registerResetButtonEventHandlers();
 	}
 
-	registerSearchButtonEventHandlers() {
+	registerSearchEventHandlers() {
+		const searchTextFields = [
+			this.termsField,
+			this.locationField
+		];
+
+		// Allow search to be initiated via Enter key.
+		for ( const field of searchTextFields ) {
+			field.control.addEventListener(
+				'keyup',
+				event => {
+					event.preventDefault();
+					if ( 13 === event.keyCode ) {
+						console.log( 'enter clicked' );
+
+						this.searchButtonField.control.click();
+					}
+				}
+			);
+		}
+
+		// Trigger search on click.
 		this.searchButtonField.control.addEventListener(
 			'wpbrControlChange',
-			event => {
+			() => {
 				this.search(
 					this.platformField.value,
 					this.termsField.value,

--- a/assets/src/js/platform-search-field.js
+++ b/assets/src/js/platform-search-field.js
@@ -164,6 +164,7 @@ class PlatformSearchField extends Field {
 		this.resetButton = null;
 		this.results.destroy();
 		this.showSearchFields();
+		this.termsField.control.focus();
 	}
 }
 


### PR DESCRIPTION
## Description

Resolves #71 by allowing platform search to be triggered via `Enter` key press.

## Types of Changes

- JS - Add event handlers to trigger search via `Enter` key press or `click`.
- UX - Improve platform search experience by allowing `Enter` key to trigger search.
- UX - Improve reset search experience by focusing the search terms field after a reset.