### PR TITLE
Allow line breaks to be toggled #78

### DIFF
--- a/assets/src/css/_components.review.scss
+++ b/assets/src/css/_components.review.scss
@@ -81,4 +81,8 @@
 			margin: 0 0 $wpbr-space;
 		}
 	}
+
+	&__omission {
+		white-space: nowrap;
+	}
 }

--- a/assets/src/js/builder.js
+++ b/assets/src/js/builder.js
@@ -121,6 +121,15 @@ class Builder {
 			this.reviewCollection.updateReviews();
 			break;
 
+		case 'line_breaks':
+			console.log('line breaks changed');
+
+			for ( const review of this.reviewCollection.reviews ) {
+				review.lineBreaks = controlValue;
+			}
+			this.reviewCollection.updateReviews();
+			break;
+
 		case 'theme':
 			this.reviewCollection.theme = controlValue;
 			this.reviewCollection.updatePresentation();

--- a/assets/src/js/field-factory.js
+++ b/assets/src/js/field-factory.js
@@ -1,6 +1,7 @@
 import BasicField from './basic-field';
 import ButtonField from './button-field';
 import CheckboxesField from './checkboxes-field';
+import RadioField from './radio-field';
 import PlatformSearchField from './platform-search-field';
 import FacebookPagesSelectField from './facebook-pages-select-field';
 
@@ -14,6 +15,9 @@ class FieldFactory {
 			break;
 		case 'checkboxes' :
 			field = new CheckboxesField( element );
+			break;
+		case 'radio' :
+			field = new RadioField( element );
 			break;
 		case 'platform_search' :
 			field = new PlatformSearchField( element );

--- a/assets/src/js/radio-field.js
+++ b/assets/src/js/radio-field.js
@@ -1,0 +1,43 @@
+import Field from './field.js';
+
+class RadioField extends Field {
+	constructor( element ) {
+		super( element );
+		this.controls = this.root.querySelectorAll( '.js-wpbr-control' );
+	}
+
+	init() {
+		this.registerControlEventHandlers();
+	}
+
+	registerControlEventHandlers() {
+		for ( const control of this.controls ) {
+			control.addEventListener( 'change', event => {
+				const controlId    = event.currentTarget.dataset.wpbrControlId;
+				const controlValue = event.currentTarget.value;
+
+				const customEvent  = new CustomEvent( 'wpbrControlChange', {
+					bubbles: true,
+					detail: {
+						controlId: controlId,
+						controlValue: controlValue
+					}
+				});
+
+				// Emit custom event that passes the control ID and value that changed.
+				control.dispatchEvent( customEvent );
+			});
+		}
+	}
+
+	// Retrieve the value of the field.
+	get value() {
+		for ( const control of this.controls ) {
+			if ( control.checked ) {
+				return control.value;
+			}
+		}
+	}
+}
+
+export default RadioField;

--- a/assets/src/js/review.js
+++ b/assets/src/js/review.js
@@ -28,6 +28,7 @@ class Review {
 		this.timestamp     = data.timestamp;
 		this.content       = data.content;
 		this.maxCharacters = data.maxCharacters || 280;
+		this.lineBreaks    = data.lineBreaks || 'disabled';
 	}
 
 	/**
@@ -93,7 +94,7 @@ class Review {
 	 * @returns string Review content markup.
 	 */
 	renderContent() {
-		let content = this.content;
+		let content     = this.content;
 		let isTruncated = false;
 
 		if ( 0 < this.maxCharacters ) {
@@ -111,15 +112,23 @@ class Review {
 			}
 		}
 
-		const arrayOfStrings = content.split( '\n' );
+		if ( 'enabled' === this.lineBreaks ) {
+			let arrayOfStrings = content.split( '\n' );
 
-		if ( isTruncated && this.reviewUrl ) {
-			arrayOfStrings[arrayOfStrings.length - 1] += ` ${this.renderOmission()}`;
+			if ( isTruncated && this.reviewUrl ) {
+				arrayOfStrings[arrayOfStrings.length - 1] += ` ${this.renderOmission()}`;
+			}
+
+			content = `
+				${arrayOfStrings.map( string => `<p>${string}</p>` ).join( '' )}
+			`;
+		} else if ( isTruncated && this.reviewUrl ) {
+			content = `<p>${content} ${this.renderOmission()}</p>`;
+		} else {
+			content = `<p>${content}</p>`;
 		}
 
-		const paragraphs = `${arrayOfStrings.map( string => `<p>${string}</p>` ).join( '' )}`;
-
-		return `<div class="wpbr-review__content">${paragraphs}</div>`;
+		return `<div class="wpbr-review__content">${content}</div>`;
 	}
 
 	renderOmission() {

--- a/assets/src/js/review.js
+++ b/assets/src/js/review.js
@@ -29,6 +29,7 @@ class Review {
 		this.content       = data.content;
 		this.maxCharacters = data.maxCharacters || 280;
 		this.lineBreaks    = data.lineBreaks || 'disabled';
+		this.isTruncated   = data.is_truncated || false;
 	}
 
 	/**
@@ -95,9 +96,10 @@ class Review {
 	 */
 	renderContent() {
 		let content     = this.content;
-		let isTruncated = false;
+		let isTruncated = this.isTruncated;
 
-		if ( 0 < this.maxCharacters ) {
+		// Only truncate if original review is not already truncated via API.
+		if ( ! this.isTruncated && 0 < this.maxCharacters ) {
 			content = truncate(
 				this.content,
 				{

--- a/assets/src/js/review.js
+++ b/assets/src/js/review.js
@@ -134,9 +134,10 @@ class Review {
 	}
 
 	renderOmission() {
+		const classAtt = 'wpbr-review__omission';
 
 		// TODO: Translate Read More in truncated excerpts.
-		return `<a href="${this.reviewUrl}" target="_blank" rel="noopener noreferrer">Read more</a>`;
+		return `<a class="${classAtt}" href="${this.reviewUrl}" target="_blank" rel="noopener noreferrer">Read more</a>`;
 	}
 }
 

--- a/config/config-builder-settings.php
+++ b/config/config-builder-settings.php
@@ -56,6 +56,16 @@ $config = array(
 				'default' => 280,
 				'placeholder' => __( 'Unlimited', 'wp-business-reviews' ),
 			),
+			'line_breaks' => array(
+				'name'    => __( 'Line Breaks', 'wp-business-reviews' ),
+				'type'    => 'radio',
+				'tooltip' => __( 'Determines whether line breaks within the review content are displayed. Not all reviews have line breaks.', 'wp-business-reviews' ),
+				'default' => 'disabled',
+				'options'  => array(
+					'enabled'  => __( 'Enabled', 'wp-business-reviews' ),
+					'disabled' => __( 'Disabled', 'wp-business-reviews' ),
+				),
+			),
 			'review_components' => array(
 				'name'    => __( 'Review Components', 'wp-business-reviews' ),
 				'type'    => 'checkboxes',

--- a/includes/request/response-normalizer/class-yelp-response-normalizer.php
+++ b/includes/request/response-normalizer/class-yelp-response-normalizer.php
@@ -148,6 +148,9 @@ class Yelp_Response_Normalizer extends Response_Normalizer_Abstract {
 			$normalized['content'] = $this->clean_multiline( $r['text'] );
 		}
 
+		// All Yelp reviews are truncated, so there's nothing to check here.
+		$normalized['is_truncated'] = true;
+
 		// Merge normalized properties with default properites in case any are missing.
 		$normalized = wp_parse_args( $normalized, $this->get_review_defaults() );
 

--- a/views/field/partials/types/radio.php
+++ b/views/field/partials/types/radio.php
@@ -13,9 +13,10 @@ if ( ! empty( $this->args['name'] ) ) {
 					<input
 						type="radio"
 						id="wpbr-control-<?php echo esc_attr( $this->id . '-' . $option_value ); ?>"
-						class="wpbr-field__radio"
+						class="wpbr-field__radio js-wpbr-control"
 						name="wp_business_reviews_settings[<?php echo esc_attr( $this->id ); ?>]"
 						value="<?php echo esc_attr( $option_value ); ?>"
+						data-wpbr-control-id="<?php echo esc_attr( $this->id ); ?>"
 						<?php checked( $option_value, $this->value ); ?>
 						>
 					<label for="wpbr-control-<?php echo esc_attr( $this->id . '-' . $option_value ); ?>">


### PR DESCRIPTION
## Description

Resolves #78 by adding `Line Breaks` control to Inspector.

## Types of Changes

- JS - Add `RadioField` class.
- UI - Add new `Line Breaks` control for toggling line breaks between paragraphs.
- PHP - Set Yelp reviews to be truncated by default, so 'Read more' link is always shown.